### PR TITLE
Fix/issue 29 Unable to install for React 17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "date-fns": "^2.14.0"
   },
   "peerDependencies": {
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-scripts": "^4.0.3"
+    "react": "^17.0.13",
+    "react-dom": "^17.0.2",
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "publish:npm": "rm -rf dist && mkdir dist && mkdir dist/components && mkdir dist/global && babel src/components -d dist/components --copy-files && babel src/global -d dist/global --copy-files",

--- a/src/components/DateView.js
+++ b/src/components/DateView.js
@@ -28,7 +28,7 @@ const DateView = ({startDate, lastDate, selectDate, getSelectedDay, primaryColor
     };
 
     const getMarked = (day) => {
-        let markedRes = marked.find(i => isSameDay(i.date, day));
+        let markedRes = marked?.find(i => isSameDay(i.date, day));
         if (markedRes) {
             if (!markedRes?.marked) {
                 return;


### PR DESCRIPTION
Changes done:
- upgrade to react 17.0.13
- fixed bug in DateView. Earlier it throws error if you don't include the type="month" attribute in DatePicker